### PR TITLE
feat: generate `help` mojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
                             <goal>descriptor</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>generate-help-mojo</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
Let the plugin be self-descriptive.

Currently:
```
$ mvn org.eclipse.cbi.central:central-staging-plugins:help
...
[ERROR] Could not find goal 'help' in plugin org.eclipse.cbi.central:central-staging-plugins:1.0.0 among available goals rc-drop, rc-list, rc-publish, rc-status, rc-upload
```

With `:help`:
```
[INFO] --- central-staging-plugins:1.0.0-SNAPSHOT:help (default-cli) @ central-staging-plugins ---
[INFO] Central Staging Plugins 1.0.0-SNAPSHOT
  Java client for Sonatype Central Portal API

central-staging-plugins:rc-list

  Available parameters:

    bearerToken
      The bearer token used for authentication with the Central Portal API.
      User property: central.bearerToken

    centralApiUrl
      The Central Portal API URL. If not set, the default is used.
      User property: central.centralApiUrl

    namespace
      The namespace to use for listing deployments. Defaults to the project's
      groupId if not set.
      User property: central.namespace

    serverId (Default: central)
      The server ID used to retrieve credentials from settings.xml.
      User property: central.serverId

    showAllDeployments (Default: false)
      If true, show all deployments. If false or not set, only show the latest.
      User property: central.showAllDeployments
```