### PR TITLE
doc: Nexus-drop documetnation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,9 +860,10 @@ The staging directory structure is controlled by two parameters:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `nexus.serverId` | String | `nexus` | Maven settings server ID for authentication |
+| `nexus.serverId` | String | `nexus` | Maven settings.xml server ID for authentication |
 | `nexus.apiUrl` | String | `https://repo3.eclipse.org/service/rest/v1` | Nexus Repository Manager API endpoint URL |
-| `nexus.bearerToken` | String | - | Authentication token for Nexus Repository Manager API |
+| `nexus.username` | String | - | The username used for authentication with the Nexus Repository Manager API. If unset, username is obtained from settings.xml |
+| `nexus.password` | String | - | The password used for authentication with the Nexus Repository Manager API. If unset, password is obtained from settings.xml |
 | `nexus.repository` | String | - | The Nexus repository to search in. If not set, searches across all repositories (slower) |
 | `nexus.group` | String | `${project.groupId}` | The group/organization/namespace to filter by (e.g., org.eclipse.example) |
 | `nexus.artifact` | String | `${project.artifactId}` | The artifact ID to filter by |


### PR DESCRIPTION
Update documentation based on changes to nexus authentication data. 
@heurtematte - is there anything else that needs to be added before a 1.4.0 release? 