### PR TITLE
Propagate `nexusArtifactsResolution` config through mojo chain

### DIFF
--- a/src/main/java/org/eclipse/cbi/central/plugin/AbstractStagingMojo.java
+++ b/src/main/java/org/eclipse/cbi/central/plugin/AbstractStagingMojo.java
@@ -307,6 +307,37 @@ public abstract class AbstractStagingMojo extends AbstractCentralMojo {
     @Parameter(property = "central.showMavenGoalOutput", defaultValue = "false")
     protected boolean showMavenGoalOutput;
 
+    // Nexus Resolution Configuration
+    /**
+     * If true, resolve artifacts by querying Nexus Repository Manager instead of
+     * inferring the artifact list from the packaging type.
+     * When enabled, the plugin calls the Nexus REST API to discover which files
+     * actually exist for the given GAV and downloads exactly those artifacts.
+     */
+    @Parameter(property = "central.nexusArtifactsResolution", defaultValue = "false")
+    protected boolean nexusArtifactsResolution;
+
+    /**
+     * Nexus Repository Manager REST API URL used when nexusArtifactsResolution is enabled.
+     * Defaults to the standard Eclipse Nexus instance when not set.
+     */
+    @Parameter(property = "nexus.apiUrl")
+    protected String nexusApiUrl;
+
+    /**
+     * Nexus repository name to scope the artifact search.
+     * If not set, the search is performed across all accessible repositories.
+     */
+    @Parameter(property = "nexus.repository")
+    protected String nexusRepository;
+
+    /**
+     * Server ID in settings.xml used to resolve Nexus API credentials.
+     * If not set, falls back to central.serverSyncId.
+     */
+    @Parameter(property = "nexus.serverId", defaultValue = "nexus")
+    protected String nexusServerId;
+
     /**
      * Maximum wait time in seconds for validation to complete.
      */

--- a/src/main/java/org/eclipse/cbi/central/plugin/RcBundleMojo.java
+++ b/src/main/java/org/eclipse/cbi/central/plugin/RcBundleMojo.java
@@ -874,6 +874,12 @@ public class RcBundleMojo extends AbstractStagingMojo {
         downloadMojo.downloadChecksums256 = this.downloadChecksums256;
         downloadMojo.downloadChecksums512 = this.downloadChecksums512;
 
+        // Nexus resolution
+        downloadMojo.nexusArtifactsResolution = this.nexusArtifactsResolution;
+        downloadMojo.nexusApiUrl = this.nexusApiUrl;
+        downloadMojo.nexusRepository = this.nexusRepository;
+        downloadMojo.nexusServerId = this.nexusServerId;
+
         // Inject Maven components
         downloadMojo.reactorProjects = this.reactorProjects;
         downloadMojo.session = this.session;

--- a/src/main/java/org/eclipse/cbi/central/plugin/RcDownloadMojo.java
+++ b/src/main/java/org/eclipse/cbi/central/plugin/RcDownloadMojo.java
@@ -15,7 +15,6 @@ package org.eclipse.cbi.central.plugin;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugin.MojoFailureException;
 
 import java.io.File;
@@ -74,38 +73,6 @@ public class RcDownloadMojo extends AbstractStagingMojo {
     // NEXUS ARTIFACT RESOLUTION PARAMETERS
     // ================================================================================================
 
-    /**
-     * If true, resolve artifacts by querying Nexus Repository Manager instead of
-     * inferring the artifact list from the packaging type.
-     * When enabled, the plugin calls the Nexus REST API to discover which files
-     * actually exist for the given GAV and downloads exactly those artifacts.
-     */
-    @Parameter(property = "central.nexusArtifactsResolution", defaultValue = "false")
-    private boolean nexusArtifactsResolution;
-
-    /**
-     * Nexus Repository Manager REST API URL used when nexusArtifactsResolution is enabled.
-     * Defaults to the standard Eclipse Nexus instance when not set.
-     * Reuses the {@code nexus.apiUrl} property shared with other nexus-* goals.
-     */
-    @Parameter(property = "nexus.apiUrl")
-    private String nexusApiUrl;
-
-    /**
-     * Nexus repository name to scope the artifact search.
-     * If not set, the search is performed across all accessible repositories.
-     * Reuses the {@code nexus.repository} property shared with other nexus-* goals.
-     */
-    @Parameter(property = "nexus.repository")
-    private String nexusRepository;
-
-    /**
-     * Server ID in settings.xml used to resolve Nexus API credentials.
-     * If not set, falls back to central.serverSyncId.
-     * Reuses the {@code nexus.serverId} property shared with other nexus-* goals.
-     */
-    @Parameter(property = "nexus.serverId", defaultValue = "nexus")
-    private String nexusServerId;
 
     /**
      * Main execution method for the rc-download Maven goal.

--- a/src/main/java/org/eclipse/cbi/central/plugin/RcSyncMojo.java
+++ b/src/main/java/org/eclipse/cbi/central/plugin/RcSyncMojo.java
@@ -206,6 +206,12 @@ public class RcSyncMojo extends AbstractStagingMojo {
         bundleMojo.mojoExecution = this.mojoExecution;
         bundleMojo.repositorySystem = this.repositorySystem;
 
+        // Nexus resolution
+        bundleMojo.nexusArtifactsResolution = this.nexusArtifactsResolution;
+        bundleMojo.nexusApiUrl = this.nexusApiUrl;
+        bundleMojo.nexusRepository = this.nexusRepository;
+        bundleMojo.nexusServerId = this.nexusServerId;
+
         // RcBundleMojo specific - force ZIP creation for sync operation
         bundleMojo.zipArtifacts = true;
 


### PR DESCRIPTION
Related to my comment in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6890#note_7307659

This is my semi-blind attempt to fix the configuration being ignored.
Note that I know next to nothing about the plugin, so if you think it is nonsense, feel free to close the PR.

In short, I think there is a bug where the configuration (and some others) aren't propagated across the `*Mojo` objects when the configurations are copied over. During rc-sync that would be `RcSyncMojo` -> `RcBundleMojo` -> `RcDownloadMojo`. In the chain, only the first Mojo would be injected into with  `@Parameter` causing the field to not be set. Moving it to `AbstractMojo` might fix it.

Though note that I didn't try it.

CC @heurtematte